### PR TITLE
Cross forks differentiation support

### DIFF
--- a/src/customizable_continuous_integration/automations/commands/write_protection_hook.py
+++ b/src/customizable_continuous_integration/automations/commands/write_protection_hook.py
@@ -57,6 +57,9 @@ def get_write_protection_script_path() -> str:
 
 def add_forked_repository(forked_repository_url, remote_name):
     cmd_output("git", "config", "--global", "--add", "safe.directory", os.getcwd())
+    ret_code, ret_stdout, ret_stderr = cmd_output("git", "remote")
+    if remote_name in ret_stdout:
+        cmd_output("git", "remote", "remove", remote_name)
     cmd_output("git", "remote", "add", remote_name, forked_repository_url)
     cmd_output("git", "remote", "update", remote_name)
 

--- a/src/customizable_continuous_integration/automations/commands/write_protection_hook.py
+++ b/src/customizable_continuous_integration/automations/commands/write_protection_hook.py
@@ -19,6 +19,7 @@ from pre_commit.git import get_all_files
 from pre_commit.lang_base import run_xargs
 from pre_commit.util import CalledProcessError, cmd_output
 
+FORKED_REPOSITORY_REMOTE_NAME = "downstream"
 
 def get_integration_test_logger() -> logging.Logger:
     _logger = logging.getLogger("write_protection_hook")
@@ -40,6 +41,7 @@ def generate_arguments_parser() -> argparse.ArgumentParser:
     args_parser.add_argument("--include-filter", default="^$", help="reg filter for files inclusion")
     args_parser.add_argument("--exclude-filter", default="^$", help="reg filter for files exclusion")
     args_parser.add_argument("--admin-list", default="", help="reg filter for files exclusion")
+    args_parser.add_argument("--forked-repository-url", default="", help="forked repository clone url")
     return args_parser
 
 
@@ -49,17 +51,30 @@ def get_write_protection_script_path() -> str:
     # in a project fs, otherwise do nothing because the project installed as a package.
     if "src/" in os.fspath(this_file_path.resolve()):
         target_cwd = this_file_path.parent.parent.parent.parent
-        script_path = os.fspath(target_cwd / "scripts" / "write-protection-pr.sh")
+        script_path = os.fspath(target_cwd / ".github" / "actions" / "write-protection-docker-action" / "write-protection-pr.sh")
     return script_path
+
+
+def add_forked_repository(forked_repository_url, remote_name):
+    cmd_output("git", "config", "--global", "--add", "safe.directory", os.getcwd())
+    cmd_output("git", "remote", "add", remote_name, forked_repository_url)
+    cmd_output("git", "remote", "update", remote_name)
 
 
 def write_protection_command(cli_args: list[str]) -> None:
     cmd = get_write_protection_script_path()
     args_parser = generate_arguments_parser()
     args = args_parser.parse_args(cli_args)
+
+    head_ref = args.head_ref
     cmd_args = []
+    if args.forked_repository_url:
+        add_forked_repository(forked_repository_url=args.forked_repository_url, remote_name=FORKED_REPOSITORY_REMOTE_NAME)
+        cmd_args = ["-r"]
+        if head_ref:
+            head_ref = f"{FORKED_REPOSITORY_REMOTE_NAME}/{head_ref}"
     if args.head_ref:
-        cmd_args.extend(["-s", args.head_ref])
+        cmd_args.extend(["-s", head_ref])
     if args.merge_ref:
         cmd_args.extend(["-t", args.merge_ref])
     if args.acting_user:


### PR DESCRIPTION
## Problem

It is nice to support the GitHub pull request across forked repositories, which is very different from the present logic handling pull requests within the same repository

## Details

1. Figure out the implementation to fetch downstream forks via GIT
2. Implement the switch for the `diff` shell script to do the same job for both cases - either cross-forks or the same repository checks.

**NOTE**: The cross-forks diff does not do the best efforts to calculate the common merge base. So the comparison happens between the exact commits in the head reference and the merge reference.